### PR TITLE
Preserving runhaskell

### DIFF
--- a/.openshift/build
+++ b/.openshift/build
@@ -69,7 +69,7 @@ if ! [ -e $PARTS_BIN/ghc ]; then
   
   #remove hp2ps and redundant shortcuts
   cd ../../bin
-  rm runhaskell haddock* hp2ps runghc* ghc ghci ghc-pkg
+  rm haddock* hp2ps ghc ghci ghc-pkg
   mv ghc-pkg-* ghcpkg
   mv ghci-* ghci
   mv ghc-* ghc


### PR DESCRIPTION
Hi!

I have noticed that runhaskell/runghc is not part of this cartridge. I am not sure if is a mistake or a design decision. If it is a mistake, I am proposing here to reintroduce them in the buildpack.

My current problem is that I actually need to be able to execute some Haskell scripts a part of a Snap application. Not having runhaskell nor runghc as part of GHC distribution prevents me from using this cartridge -  which aside of that works fine :)

I think that the few extra bits of this binary worth the functionality added 